### PR TITLE
Add Scheels invoice webapp

### DIFF
--- a/agents/invoice-webapp/README.md
+++ b/agents/invoice-webapp/README.md
@@ -1,0 +1,22 @@
+# Scheels Invoice Webapp
+
+This sample demonstrates a simple Flask application for uploading and parsing PDF invoices using Google Document AI. It includes a minimal front end styled with Scheels brand colors and supports drag-and-drop uploads of multiple PDFs. Parsed results are stored in Google Cloud Storage and BigQuery.
+
+## Features
+- Drag and drop or select multiple PDF files.
+- Duplicate detection against stored invoices.
+- Result page displaying parsed fields and generated summary.
+- Admin page showing total invoices processed and totals by vendor.
+- Spinner overlay while uploads are processed.
+- Manual approval when confidence is below 80%.
+
+## Running
+1. Install dependencies with `pip install flask google-cloud-storage google-cloud-bigquery google-cloud-documentai vertexai`.
+2. Ensure Google credentials are configured and update the configuration values in `app.py`.
+3. Run the app:
+
+```bash
+python app.py
+```
+
+Visit `http://localhost:8080` to upload invoices.

--- a/agents/invoice-webapp/app.py
+++ b/agents/invoice-webapp/app.py
@@ -1,0 +1,157 @@
+import os
+import json
+from datetime import timedelta
+from flask import Flask, render_template, request, jsonify, redirect, url_for
+from google.cloud import storage, bigquery, documentai_v1 as documentai
+from vertexai.preview.generative_models import GenerativeModel
+import vertexai
+
+os.environ.setdefault("GOOGLE_APPLICATION_CREDENTIALS", "sis-2025-hackathon-35428220c444.json")
+
+project_id = "sis-2025-hackathon"
+location = "us"
+processor_id = "689768479d899f32"
+bucket_name = "ltl_invoice"
+upload_prefix = "invoices/"
+parsed_prefix = "parsed/"
+bq_dataset = "invoice_data"
+bq_table = "invoices"
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('upload.html')
+
+@app.route('/upload', methods=['POST'])
+def upload_file():
+    files = request.files.getlist('files')
+    results = []
+    bq_client = bigquery.Client()
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    try:
+        for file in files:
+            filename = file.filename
+            blob_path = f"{upload_prefix}{filename}"
+            blob = bucket.blob(blob_path)
+            blob.upload_from_file(file, content_type='application/pdf')
+
+            content = blob.download_as_bytes()
+            doc = parse_documentai(content)
+            parsed = extract_fields(doc)
+            parsed["summary"] = generate_summary(parsed)
+            parsed["gcs_uri"] = f"gs://{bucket_name}/{blob_path}"
+            parsed["view_url"] = blob.generate_signed_url(version="v4", expiration=timedelta(minutes=15), method="GET")
+            parsed["file_name"] = filename
+
+            duplicates = check_duplicate(parsed.get("invoice_id"), parsed.get("supplier_name"))
+            if duplicates:
+                return render_template('duplicate.html', invoice=parsed, matches=duplicates)
+
+            parsed["needs_approval"] = parsed.get("document_confidence", 0) < 0.8
+
+            if not parsed["needs_approval"]:
+                json_blob = bucket.blob(f"{parsed_prefix}{filename.replace('.pdf', '.json')}")
+                json_blob.upload_from_string(json.dumps(parsed, indent=2), content_type="application/json")
+                table_ref = bq_client.dataset(bq_dataset).table(bq_table)
+                bq_client.insert_rows_json(table_ref, [parsed])
+
+            results.append(parsed)
+        return render_template('result.html', invoices=results)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@app.route('/admin')
+def admin():
+    try:
+        bq_client = bigquery.Client()
+        total_query = f"SELECT COUNT(*) AS count FROM `{project_id}.{bq_dataset}.{bq_table}`"
+        total_count = list(bq_client.query(total_query))[0].count
+        totals_query = f"""
+            SELECT supplier_name AS vendor, COUNT(*) AS count, SUM(CAST(total_amount AS FLOAT64)) AS amount
+            FROM `{project_id}.{bq_dataset}.{bq_table}`
+            GROUP BY vendor
+        """
+        totals = [dict(row) for row in bq_client.query(totals_query)]
+        return render_template('admin.html', total_count=total_count, totals=totals)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+def parse_documentai(content_bytes):
+    client = documentai.DocumentProcessorServiceClient()
+    name = f"projects/{project_id}/locations/{location}/processors/{processor_id}"
+    raw_doc = documentai.RawDocument(content=content_bytes, mime_type="application/pdf")
+    request = documentai.ProcessRequest(name=name, raw_document=raw_doc)
+    result = client.process_document(request=request)
+    return result.document
+
+def extract_fields(document):
+    fields = {}
+    confidences = []
+    for entity in document.entities:
+        key = entity.type_.strip().lower()
+        val = entity.mention_text.replace("\n", " ").strip()
+        fields[key] = val
+        if entity.confidence is not None:
+            confidences.append(entity.confidence)
+    avg_conf = round(sum(confidences) / len(confidences), 4) if confidences else 0.0
+    fields["document_confidence"] = avg_conf
+    return fields
+
+def check_duplicate(invoice_id, supplier_name):
+    if not invoice_id or not supplier_name:
+        return []
+    bq_client = bigquery.Client()
+    query = f"""
+        SELECT * FROM `{project_id}.{bq_dataset}.{bq_table}`
+        WHERE invoice_id = @invoice_id AND supplier_name = @supplier_name
+    """
+    job_config = bigquery.QueryJobConfig(query_parameters=[
+        bigquery.ScalarQueryParameter("invoice_id", "STRING", invoice_id),
+        bigquery.ScalarQueryParameter("supplier_name", "STRING", supplier_name),
+    ])
+    result = bq_client.query(query, job_config=job_config)
+    return [dict(row) for row in result]
+
+def generate_summary(parsed_fields):
+    vertexai.init(project=project_id, location="us-central1")
+    model = GenerativeModel("gemini-2.0-flash-lite-001")
+    prompt = f"""
+    Create a one-sentence summary of this invoice:
+    - Invoice ID: {parsed_fields.get('invoice_id', '')}
+    - Supplier: {parsed_fields.get('supplier_name', '')}
+    - Receiver: {parsed_fields.get('receiver_name', '')}
+    - Amount: {parsed_fields.get('total_amount', '')} {parsed_fields.get('currency', '')}
+    - Due date: {parsed_fields.get('due_date', '')}
+    - Terms: {parsed_fields.get('payment_terms', '')}
+    - Carrier: {parsed_fields.get('carrier', '')}
+    """
+    try:
+        response = model.generate_content(prompt.strip())
+        return response.text.strip()
+    except Exception as e:
+        return f"(Failed to generate summary: {e})"
+
+
+@app.route('/approve', methods=['POST'])
+def approve():
+    data = json.loads(request.form['data'])
+    filename = data.get('file_name', 'invoice.pdf')
+    try:
+        storage_client = storage.Client()
+        bucket = storage_client.bucket(bucket_name)
+        json_blob = bucket.blob(f"{parsed_prefix}{filename.replace('.pdf', '.json')}")
+        json_blob.upload_from_string(json.dumps(data, indent=2), content_type="application/json")
+
+        bq_client = bigquery.Client()
+        table_ref = bq_client.dataset(bq_dataset).table(bq_table)
+        bq_client.insert_rows_json(table_ref, [data])
+
+        data['needs_approval'] = False
+        return render_template('result.html', invoices=[data], approved=True)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/agents/invoice-webapp/static/styles.css
+++ b/agents/invoice-webapp/static/styles.css
@@ -1,0 +1,70 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f8f8f8;
+}
+header {
+    background-color: #cc0000; /* Scheels red */
+    color: white;
+    padding: 1rem;
+    text-align: center;
+}
+main {
+    padding: 2rem;
+}
+.upload-area {
+    border: 2px dashed #cc0000;
+    background-color: #fff;
+    padding: 2rem;
+    text-align: center;
+    cursor: pointer;
+}
+.upload-area.dragover {
+    background-color: #ffeeee;
+}
+table {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 1rem;
+}
+th, td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    text-align: left;
+}
+button {
+    background-color: #cc0000;
+    border: none;
+    color: white;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+}
+button:hover {
+    background-color: #a30000;
+}
+
+.spinner-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.8);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+.spinner {
+    border: 8px solid #f3f3f3;
+    border-top: 8px solid #cc0000;
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    animation: spin 1s linear infinite;
+}
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/agents/invoice-webapp/templates/admin.html
+++ b/agents/invoice-webapp/templates/admin.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}Admin Stats{% endblock %}
+{% block content %}
+<h2>Admin Statistics</h2>
+<p>Total Invoices Parsed: {{ total_count }}</p>
+<table>
+<tr><th>Vendor</th><th>Invoice Count</th><th>Total Amount</th></tr>
+{% for row in totals %}
+<tr><td>{{ row.vendor }}</td><td>{{ row.count }}</td><td>{{ row.amount }}</td></tr>
+{% endfor %}
+</table>
+{% endblock %}

--- a/agents/invoice-webapp/templates/base.html
+++ b/agents/invoice-webapp/templates/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Scheels Invoice Parser{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <header>
+        <h1>Scheels Invoice Parser</h1>
+    </header>
+    <main>
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/agents/invoice-webapp/templates/duplicate.html
+++ b/agents/invoice-webapp/templates/duplicate.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block title %}Duplicate Invoice{% endblock %}
+{% block content %}
+<h2>Duplicate Detected</h2>
+<p>The uploaded invoice matches an existing record.</p>
+<h3>Current Invoice</h3>
+<table>
+{% for key, value in invoice.items() %}
+<tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+{% endfor %}
+</table>
+<h3>Existing Records</h3>
+<table>
+<tr>
+{% for key in matches[0].keys() %}<th>{{ key }}</th>{% endfor %}
+</tr>
+{% for row in matches %}
+<tr>{% for val in row.values() %}<td>{{ val }}</td>{% endfor %}</tr>
+{% endfor %}
+</table>
+<form action="/" method="get">
+    <button type="submit">Upload Another PDF</button>
+</form>
+{% endblock %}

--- a/agents/invoice-webapp/templates/result.html
+++ b/agents/invoice-webapp/templates/result.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block title %}Results{% endblock %}
+{% block content %}
+<h2>Parsed Results</h2>
+{% if approved %}<p>Upload approved and stored.</p>{% endif %}
+{% for invoice in invoices %}
+<h3>Invoice {{ loop.index }}</h3>
+<p><a href="{{ invoice.view_url }}" target="_blank">View PDF</a></p>
+<table>
+    {% for key, value in invoice.items() %}
+    <tr><th>{{ key }}</th><td>{{ value }}</td></tr>
+    {% endfor %}
+</table>
+{% if invoice.needs_approval %}
+<p>Confidence {{ invoice.document_confidence }} is below 0.8. Please confirm upload.</p>
+<form action="/approve" method="post">
+    <input type="hidden" name="data" value='{{ invoice|tojson }}'>
+    <button type="submit">Approve Upload</button>
+</form>
+{% endif %}
+{% endfor %}
+<form action="/" method="get">
+    <button type="submit">Upload More PDFs</button>
+</form>
+{% endblock %}

--- a/agents/invoice-webapp/templates/upload.html
+++ b/agents/invoice-webapp/templates/upload.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% block title %}Upload Invoices{% endblock %}
+{% block head %}
+<script>
+function showSpinner() {
+  document.getElementById('spinner').style.display = 'flex';
+}
+function handleFiles(files) {
+  document.getElementById('file-input').files = files;
+  showSpinner();
+  document.getElementById('upload-form').submit();
+}
+function initDragAndDrop() {
+  const area = document.getElementById('upload-area');
+  area.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    area.classList.add('dragover');
+  });
+  area.addEventListener('dragleave', () => {
+    area.classList.remove('dragover');
+  });
+  area.addEventListener('drop', (e) => {
+    e.preventDefault();
+    area.classList.remove('dragover');
+    handleFiles(e.dataTransfer.files);
+  });
+}
+window.addEventListener('DOMContentLoaded', initDragAndDrop);
+</script>
+{% endblock %}
+{% block content %}
+<h2>Upload PDF Invoices</h2>
+<form id="upload-form" action="/upload" method="post" enctype="multipart/form-data">
+    <div id="upload-area" class="upload-area">
+        Drag and drop PDFs here or click to select
+        <input id="file-input" type="file" name="files" accept="application/pdf" multiple style="display:none" onchange="handleFiles(this.files)">
+    </div>
+</form>
+<div id="spinner" class="spinner-overlay"><div class="spinner"></div></div>
+<script>
+document.getElementById('upload-area').onclick = () => document.getElementById('file-input').click();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create Scheels-themed invoice parsing webapp
- implement drag & drop PDF uploads with multi-file support
- show parsed results and duplicate screen
- add admin page for totals by vendor
- introduce spinner and manual approval for low-confidence uploads

## Testing
- `python -m py_compile agents/invoice-webapp/app.py`
